### PR TITLE
Do not pass the host to Runspaces

### DIFF
--- a/DynamicTitle/Private/Thread.ps1
+++ b/DynamicTitle/Private/Thread.ps1
@@ -1,13 +1,6 @@
-function StartThread([ScriptBlock]$scriptBlock, $arguments, $psHost)
+function StartThread([ScriptBlock]$scriptBlock, $arguments)
 {
-    if ($psHost)
-    {
-        $runspace = [RunSpaceFactory]::CreateRunspace($psHost)
-    }
-    else
-    {
-        $runspace = [RunSpaceFactory]::CreateRunspace()
-    }
+    $runspace = [RunSpaceFactory]::CreateRunspace()
     $runspace.Open()
 
     $powershell = [PowerShell]::Create()

--- a/DynamicTitle/Public/Start-DTJobBackgroundThreadTimer.ps1
+++ b/DynamicTitle/Public/Start-DTJobBackgroundThreadTimer.ps1
@@ -89,7 +89,7 @@ function Start-DTJobBackgroundThreadTimer
             }
         }
 
-        $thread = StartThread $threadFunc $arguments $host
+        $thread = StartThread $threadFunc $arguments
 
         $job = [PSCustomObject]@{
             Sync = $sync

--- a/DynamicTitle/Public/Start-DTTitle.ps1
+++ b/DynamicTitle/Public/Start-DTTitle.ps1
@@ -85,6 +85,7 @@ function Start-DTTitle
         $horizontalScrollWaitFrame = [Int]($HorizontalScrollWaitMilliseconds / $UpdateIntervalMilliseconds)
 
         $arguments = @{
+            host = $host
             scriptBlock = $ScriptBlock.Ast.GetScriptBlock()
             argumentList = $ArgumentList
             intervalMilliseconds = $UpdateIntervalMilliseconds
@@ -115,12 +116,12 @@ function Start-DTTitle
             while ($dynamicTitleUpdateMain.Tick())
             {
                 $private:titleLines = [string[]]@($args.scriptBlock.Invoke($args.argumentList))
-                $host.UI.RawUI.WindowTitle = $dynamicTitleUpdateMain.GetTitle($titleLines)
+                $args.host.UI.RawUI.WindowTitle = $dynamicTitleUpdateMain.GetTitle($titleLines)
             }
         }
 
         $originalTitle = $host.UI.RawUI.WindowTitle
-        $thread = StartThread $threadFunc $arguments $host
+        $thread = StartThread $threadFunc $arguments
         $script:globalStore.SetTitleUpdateThread($thread, $originalTitle)
     }
 }


### PR DESCRIPTION
ConsoleMode change on the background thread seems to be affecting the main thread on the conhost.exe.

Since we don't use the host output, there is no need to pass the $host to other Runspaces.